### PR TITLE
Fix dup variants causing 'Reference and alternate allelse are the same' error

### DIFF
--- a/hgvs-api/hgvs_api/service/coordinates.py
+++ b/hgvs-api/hgvs_api/service/coordinates.py
@@ -143,15 +143,9 @@ def get_coordinates(hgvs_string):
     # if not valid:
     #     return 'Invalid HGVS'
 
-    # 3. Normalize
-    if valid:
-        try:
-            n = hn.normalize(v)
-        except HGVSError as e:
-            return repr(e)
-    else:
-        # pretend the intronic variants are valid
-        n = v
+    # # 3. Normalize
+    # TODO Normalization has been giving issues with valid HGVS strings, so disable for now
+    n = v
 
     # 4. Map to our transcript versions
     assembly = 'None'
@@ -189,9 +183,12 @@ def get_coordinates(hgvs_string):
         return f'Reference assembly "{g.ac}" not found in hg38 or hg37'
 
     alt = ''
+    ref = ''
     if g.posedit.edit.type == 'dup':
         alt = g.posedit.edit.ref
+        ref = ''
     else:
+        ref = g.posedit.edit.ref
         alt = g.posedit.edit.alt
     return {
         "original": str(hgvs_string),
@@ -199,7 +196,7 @@ def get_coordinates(hgvs_string):
         "assembly": assembly,
         "chrom": chrom,
         "pos": g.posedit.pos.start.base,
-        "ref": format_ref_or_alt(g.posedit.edit.ref),
+        "ref": format_ref_or_alt(ref),
         "alt": format_ref_or_alt(alt),
         "is_valid": valid
     }

--- a/hgvs-api/hgvs_api/tests/test_service_coordinates.py
+++ b/hgvs-api/hgvs_api/tests/test_service_coordinates.py
@@ -61,6 +61,9 @@ many_hgvs = [
 bad_hgvs = 'bad_should_error'
 almost_good_hgvs = 'AA_0001234.1:g.12345a>c'
 
+dup_hgvs = 'NM_000492.4:c.2046dup'
+dup_resp = {'alt': 'A', 'assembly': 'hg38', 'chrom': 'chr7', 'hgvs': 'NC_000007.14:g.117592219dup', 'is_valid': True, 'original': 'NM_000492.4:c.2046dup', 'pos': 117592219, 'ref': '-'}
+
 class TestServiceCoordinates(unittest.TestCase):
     def test_format_ref_or_alt(self):
         upper_a = coordinates.format_ref_or_alt('A')
@@ -104,6 +107,11 @@ class TestServiceCoordinates(unittest.TestCase):
     def test_coordinates_almost_good_hgvs(self):
         resp = coordinates.get_coordinates(almost_good_hgvs)
         self.assertTrue(resp.find('HGVSDataNotAvailableError') >= 0)
+
+    def test_coordinates_duplicate_should_look_like_insert(self):
+        resp = coordinates.get_coordinates(dup_hgvs)
+        self.assertEqual(dup_resp, resp)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* old: `ref: 'A', alt: 'A'`
* new: `ref: '-', alt: 'A'`
* Add a test case for the dup string
* Remove the normalization step of the HGVS conversion, it was causing errors in some cases when the string could still be converted to coordinates