### PR TITLE
Fix/395/hgvs deletion error

### DIFF
--- a/hgvs-api/hgvs_api/service/coordinates.py
+++ b/hgvs-api/hgvs_api/service/coordinates.py
@@ -143,9 +143,16 @@ def get_coordinates(hgvs_string):
     # if not valid:
     #     return 'Invalid HGVS'
 
-    # # 3. Normalize
-    # TODO Normalization has been giving issues with valid HGVS strings, so disable for now
-    n = v
+    # 3. Normalize
+    if valid:
+        try:
+            n = hn.normalize(v)
+        except HGVSError as e:
+            # pretend the intronic variants are valid
+            n = v
+    else:
+        # pretend the intronic variants are valid
+        n = v
 
     # 4. Map to our transcript versions
     assembly = 'None'

--- a/hgvs-api/hgvs_api/tests/test_service_coordinates.py
+++ b/hgvs-api/hgvs_api/tests/test_service_coordinates.py
@@ -1,17 +1,16 @@
 import unittest
 from service import coordinates
 
-
 good_hgvs = 'NC_000023.11:g.32389644G>A'
 good_hgvs_resp = {
-  "alt": "A",
-  "assembly": "hg38",
-  "chrom": "chrX",
-  "hgvs": "NC_000023.11:g.32389644G>A",
-  "is_valid": True,
-  "original": "NC_000023.11:g.32389644G>A",
-  "pos": 32389644,
-  "ref": "G"
+    "alt": "A",
+    "assembly": "hg38",
+    "chrom": "chrX",
+    "hgvs": "NC_000023.11:g.32389644G>A",
+    "is_valid": True,
+    "original": "NC_000023.11:g.32389644G>A",
+    "pos": 32389644,
+    "ref": "G"
 }
 
 ensembl_hgvs = 'ENST00000380152.8:c.-199A>C'
@@ -64,6 +63,31 @@ almost_good_hgvs = 'AA_0001234.1:g.12345a>c'
 dup_hgvs = 'NM_000492.4:c.2046dup'
 dup_resp = {'alt': 'A', 'assembly': 'hg38', 'chrom': 'chr7', 'hgvs': 'NC_000007.14:g.117592219dup', 'is_valid': True, 'original': 'NM_000492.4:c.2046dup', 'pos': 117592219, 'ref': '-'}
 
+del_hgvs = 'NC_000019.10:g.12943758_12943809del'
+del_resp = {
+    'alt': '-',
+    'assembly': 'hg38',
+    'chrom': 'chr19',
+    'hgvs': 'NC_000019.10:g.12943758_12943809del',
+    'is_valid': True,
+    'original': 'NC_000019.10:g.12943758_12943809del',
+    'pos': 12943758,
+    'ref': 'CTTAAGGAGGAGGAAGAAGACAAGAAACGCAAAGAGGAGGAGGAGGCAGAGG'
+}
+
+simple_del_hgvs = 'NC_000017.11:g.58357806del'
+simple_del_resp = {
+    'alt': '-',
+    'assembly': 'hg38',
+    'chrom': 'chr17',
+    'hgvs': 'NC_000017.11:g.58357806del',
+    'is_valid': True,
+    'original': 'NC_000017.11:g.58357806del',
+    'pos': 58357806,
+    'ref': 'C'
+}
+
+
 class TestServiceCoordinates(unittest.TestCase):
     def test_format_ref_or_alt(self):
         upper_a = coordinates.format_ref_or_alt('A')
@@ -112,6 +136,11 @@ class TestServiceCoordinates(unittest.TestCase):
         resp = coordinates.get_coordinates(dup_hgvs)
         self.assertEqual(dup_resp, resp)
 
+    def test_coordinates_delete(self):
+        resp = coordinates.get_coordinates(del_hgvs)
+        self.assertEqual(del_resp, resp)
+        resp = coordinates.get_coordinates(simple_del_hgvs)
+        self.assertEqual(simple_del_resp, resp)
 
 
 if __name__ == '__main__':

--- a/hgvs-api/hgvs_api/tests/test_service_coordinates.py
+++ b/hgvs-api/hgvs_api/tests/test_service_coordinates.py
@@ -130,7 +130,7 @@ class TestServiceCoordinates(unittest.TestCase):
 
     def test_coordinates_almost_good_hgvs(self):
         resp = coordinates.get_coordinates(almost_good_hgvs)
-        self.assertTrue(resp.find('HGVSDataNotAvailableError') >= 0)
+        self.assertTrue(resp.find('not found in hg38 or hg37') >= 0)
 
     def test_coordinates_duplicate_should_look_like_insert(self):
         resp = coordinates.get_coordinates(dup_hgvs)


### PR DESCRIPTION
- Re-add the normalization step to the HGVS conversion process. This step ensures we have the reference bases for deletion events.
- Add unit test for deletion events
- Fix 'almost good' hgvs test due to differing handling of the failed normalization process.
 